### PR TITLE
Fix decoding of ggpack files from latest Thimbleweed Park

### DIFF
--- a/ggdump/ggdump.py
+++ b/ggdump/ggdump.py
@@ -130,26 +130,13 @@ class GGDump:
             print('Writing: ' + rec[0])
 
 def decode_unbreakable_xor(src):
-    magic_bytes = b'\x4F\xD0\xA0\xAC\x4A\x5B\xB9\xE5\x93\x79\x45\xA5\xC1\xCB\x31\x93'
+    magic_bytes = b'\x4F\xD0\xA0\xAC\x4A\x56\xB9\xE5\x93\x79\x45\xA5\xC1\xCB\x31\x93'
     buffer = bytearray(src)
     buf_len = len(src)
 
-    eax = buf_len
-    var4 = buf_len & 0xFF
-    ebx = 0
-    while ebx < buf_len:
-        eax = ebx & 0xFF
-        eax = eax * 0x6D
-        ecx = ebx & 0x0F
-        eax = (eax ^ magic_bytes[ecx]) & 0xFF
-        ecx = var4
-        eax = (eax ^ ecx) & 0xFF
-        buffer[ebx] = buffer[ebx] ^ eax
-        ecx = ecx ^ buffer[ebx]
-        ebx = ebx + 1
-        var4 = ecx
-    for i in range(5, buf_len - 5, 16):
-        buffer[i] = buffer[i] ^ 0x0D
-    for i in range(6, buf_len - 6, 16):
-        buffer[i] = buffer[i] ^ 0x0D
+    xor_sum = buf_len & 0xFF
+    for i in range(buf_len):
+        buffer[i] = ((-i*0x53) & 0xFF) ^ buffer[i] ^ xor_sum ^ magic_bytes[i & 0x0F]
+        xor_sum ^= buffer[i]
+
     return bytes(buffer)


### PR DESCRIPTION
Tested with Linux GOG version 1.0.958. <s>Would be nice if someone could test with the Steam version.</s> (Edit: I've asked someone who owns it on Steam and apparently the data files are identical.)

SHA256 sums:
```
a6fb27f14ae1a8b80fbd4a92e4aff11a40df2c81079c8cc77b1e6b0f4f00b5e8  ThimbleweedPark.ggpack1
734c15005c3bc93e2869f250fcc6517990cfcc46ef4c4a4eb4d48fff329d30c3  ThimbleweedPark.ggpack2
```